### PR TITLE
Bounds check should be > 42.

### DIFF
--- a/Classes/ARC/cgeohash.m
+++ b/Classes/ARC/cgeohash.m
@@ -94,7 +94,7 @@ GEOHASH_verify_hash(const char *hash)
         if (c < 0x30)
             return false;
         c -= 0x30;
-        if (c > 43)
+        if (c > 42)
             return false;
         if (BASE32_DECODE_TABLE[c] == -1)
             return false;

--- a/Classes/NonARC/cgeohash.m
+++ b/Classes/NonARC/cgeohash.m
@@ -94,7 +94,7 @@ GEOHASH_verify_hash(const char *hash)
         if (c < 0x30)
             return false;
         c -= 0x30;
-        if (c > 43)
+        if (c > 42)
             return false;
         if (BASE32_DECODE_TABLE[c] == -1)
             return false;


### PR DESCRIPTION
\> 43 would allow the character ] in a geohash, which is not in either translating table.

] means c takes the value 91, then 48 is subtracted = 43. The bounds check does not hit, and we access the \0 at the end of the table.